### PR TITLE
Refactor Invoke-SeasonEpisodeNaming

### DIFF
--- a/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
@@ -1,0 +1,21 @@
+BeforeAll {
+    . $PSScriptRoot\Invoke-SeasonEpisodeNaming.ps1
+}
+
+Describe 'Sort-ByTitle' {
+    It 'Should Sort Correctly' {
+        # Arrange
+        $files = @(
+            'T:\S1D1\A1_t10',
+            'T:\S1D1\C1_t9',
+            'T:\S1D1\D1_t8'
+        )
+
+        # Act
+        $actual = Sort-ByTitle -Files $files
+
+        # Assert
+        $actual.Keys | Should -Be @(8, 9, 10)
+        $actual.Values | Should -Be @('T:\S1D1\D1_t8', 'T:\S1D1\C1_t9', 'T:\S1D1\A1_t10')
+    }
+}

--- a/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
@@ -36,4 +36,20 @@ Describe 'Get-RenameOperations' {
         $actual['T:\S1D1\C1_t9.mkv'] | Should -Be 'T:\S1D1\S01E02.mkv'
         $actual['T:\S1D1\A1_t10.mkv'] | Should -Be 'T:\S1D1\S01E03.mkv'
     }
+
+    It 'Should Support Double Episodes' {
+        # Arrange
+        [System.Collections.Generic.SortedDictionary[int, string]]$sortedDictionary = [System.Collections.Generic.SortedDictionary[int, string]]::new()
+        $sortedDictionary.Add(8, 'T:\S1D1\D1_t8.mkv')
+        $sortedDictionary.Add(9, 'T:\S1D1\C1_t9.mkv')
+        $sortedDictionary.Add(10, 'T:\S1D1\A1_t10.mkv')
+
+        # Act
+        $actual = Get-RenameOperations -TitleOrder $sortedDictionary -Season 1 -StartEpisode 1 -TreatAsDoubleEpisode $true
+
+        # Assert
+        $actual['T:\S1D1\D1_t8.mkv'] | Should -Be 'T:\S1D1\S01E01E02.mkv'
+        $actual['T:\S1D1\C1_t9.mkv'] | Should -Be 'T:\S1D1\S01E03E04.mkv'
+        $actual['T:\S1D1\A1_t10.mkv'] | Should -Be 'T:\S1D1\S01E05E06.mkv'
+    }
 }

--- a/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
@@ -6,9 +6,9 @@ Describe 'Sort-ByTitle' {
     It 'Should Sort Correctly' {
         # Arrange
         $files = @(
-            'T:\S1D1\A1_t10',
-            'T:\S1D1\C1_t9',
-            'T:\S1D1\D1_t8'
+            'T:\S1D1\A1_t10.mkv',
+            'T:\S1D1\C1_t9.mkv',
+            'T:\S1D1\D1_t8.mkv'
         )
 
         # Act
@@ -16,6 +16,24 @@ Describe 'Sort-ByTitle' {
 
         # Assert
         $actual.Keys | Should -Be @(8, 9, 10)
-        $actual.Values | Should -Be @('T:\S1D1\D1_t8', 'T:\S1D1\C1_t9', 'T:\S1D1\A1_t10')
+        $actual.Values | Should -Be @('T:\S1D1\D1_t8.mkv', 'T:\S1D1\C1_t9.mkv', 'T:\S1D1\A1_t10.mkv')
+    }
+}
+
+Describe 'Get-RenameOperations' {
+    It 'Should Rename Correctly' {
+        # Arrange
+        [System.Collections.Generic.SortedDictionary[int, string]]$sortedDictionary = [System.Collections.Generic.SortedDictionary[int, string]]::new()
+        $sortedDictionary.Add(8, 'T:\S1D1\D1_t8.mkv')
+        $sortedDictionary.Add(9, 'T:\S1D1\C1_t9.mkv')
+        $sortedDictionary.Add(10, 'T:\S1D1\A1_t10.mkv')
+
+        # Act
+        $actual = Get-RenameOperations -TitleOrder $sortedDictionary -Season 1 -StartEpisode 1
+
+        # Assert
+        $actual['T:\S1D1\D1_t8.mkv'] | Should -Be 'T:\S1D1\S01E01.mkv'
+        $actual['T:\S1D1\C1_t9.mkv'] | Should -Be 'T:\S1D1\S01E02.mkv'
+        $actual['T:\S1D1\A1_t10.mkv'] | Should -Be 'T:\S1D1\S01E03.mkv'
     }
 }

--- a/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
@@ -1,8 +1,8 @@
 # The intent of this script is to help with mass renaming files ripped via
 # MakeMKV to the format S00E00 by giving the Season and Start Episode and then
-# assuming that the order of the files (IE C_T01.mkv, C_T02.mkv) will be the
-# order of the Episodes. It will also rename the parent folder to the format
-# `Season.SeasonNumber` to assist Filebot.
+# assuming that the order of the files based on the Title (IE C_T01.mkv,
+# C_T02.mkv) will be the order of the Episodes. It will also rename the parent
+# folder to the format `Season.SeasonNumber` to assist Filebot.
 function Invoke-SeasonEpisodeNaming {
     [CmdletBinding()]
     param (
@@ -20,10 +20,25 @@ function Invoke-SeasonEpisodeNaming {
         if (Test-Path $Path) {
             $filesInFolder = Get-ChildItem -LiteralPath $Path | Sort-Object -Property Name | Select-Object -ExpandProperty FullName
 
+            # We need to sort this by the Title
+            [System.Collections.Generic.SortedDictionary[string, string]]$titleSort = [System.Collections.Generic.SortedDictionary[string, string]]::new()
+            foreach ($file in $filesInFolder) {
+                $fileNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($file)
+                $title = [System.Text.RegularExpressions.Regex]::Match($fileNameWithoutExtension, '[A-Z][0-9]_t(?<TitleNumber>[0-9]+)').Groups['TitleNumber'].Value
+                if ($titleSort.ContainsKey($title)) {
+                    Write-Error "Duplicate Titles Found; This Tool Cannot Be Used"
+                    exit
+                }
+                else {
+                    $titleSort.Add($title, $file)
+                }
+            }
+
             $currentEpisode = [int]::Parse($StartEpisode)
 
             # Rename all the files in S00E00 Format
-            foreach ($file in $filesInFolder) {
+            foreach ($fileKvp in $titleSort.GetEnumerator()) {
+                $file = $fileKvp.Value
                 $parentFolder = [System.IO.Path]::GetDirectoryName($file)
                 $fileExtension = [System.IO.Path]::GetExtension($file)
                 $newName = "S$($Season.PadLeft(2,'0'))E$($currentEpisode.ToString().PadLeft(2,'0'))$fileExtension"

--- a/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
@@ -14,7 +14,10 @@ function Invoke-SeasonEpisodeNaming {
         $Season,
         [Parameter(Position = 2, Mandatory = $true)]
         [string]
-        $StartEpisode
+        $StartEpisode,
+        [Parameter(Position = 3, Mandatory = $false)]
+        [bool]
+        $TreatAsDoubleEpisode = $false
     )
     process {
         if (Test-Path $Path) {
@@ -22,7 +25,7 @@ function Invoke-SeasonEpisodeNaming {
 
             $titleSort = Sort-ByTitle -Files $filesInFolder
 
-            $renameOperations = Get-RenameOperations -TitleOrder $titleSort -Season $Season -StartEpisode $StartEpisode
+            $renameOperations = Get-RenameOperations -TitleOrder $titleSort -Season $Season -StartEpisode $StartEpisode -TreatAsDoubleEpisode $TreatAsDoubleEpisode
 
             foreach ($renameOperation in $renameOperations.GetEnumerator()) {
                 Move-Item -LiteralPath $renameOperation.Key -Destination $renameOperation.Value
@@ -82,7 +85,10 @@ function Get-RenameOperations {
         $Season,
         [Parameter(Position = 2, Mandatory = $true)]
         [string]
-        $StartEpisode
+        $StartEpisode,
+        [Parameter(Position = 3, Mandatory = $false)]
+        [bool]
+        $TreatAsDoubleEpisode = $false
     )
     process {
         [System.Collections.Generic.Dictionary[string, string]]$renameOperations = [System.Collections.Generic.Dictionary[string, string]]::new()
@@ -94,7 +100,14 @@ function Get-RenameOperations {
             $file = $fileKvp.Value
             $parentFolder = [System.IO.Path]::GetDirectoryName($file)
             $fileExtension = [System.IO.Path]::GetExtension($file)
-            $newName = "S$($Season.PadLeft(2,'0'))E$($currentEpisode.ToString().PadLeft(2,'0'))$fileExtension"
+            if ($TreatAsDoubleEpisode) {
+                $firstEpisode = $currentEpisode
+                $currentEpisode++
+                $newName = "S$($Season.PadLeft(2,'0'))E$($firstEpisode.ToString().PadLeft(2,'0'))E$($currentEpisode.ToString().PadLeft(2,'0'))$fileExtension"
+            }
+            else {
+                $newName = "S$($Season.PadLeft(2,'0'))E$($currentEpisode.ToString().PadLeft(2,'0'))$fileExtension"
+            }
             $newPath = [System.IO.Path]::Combine($parentFolder, $newName)
             $renameOperations.Add($file, $newPath)
             $currentEpisode++


### PR DESCRIPTION
Refactored `Invoke-SeasonEpisodeNaming` to provide for the ability to sort by `Title`, as defined by extracting it from `A1_tXX`. This resolves most of the issues that prevent us from just using Filebot.

Extracted out much of the logic into various sub-methods to allow them to be Unit Testable (Pester).

Added support for `Double Episode` Naming Schemes via an optional boolean (`TreatAsDoubleEpisode`).