### PR TITLE
Add Support for Numerics at the End of a Filename

### DIFF
--- a/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.Tests.ps1
@@ -23,15 +23,33 @@ Describe 'Sort-ByTitle' {
         # Arrange
         $files = @(
             'T:\S1D1\Some Title_t01',
-            'T:\S1D1\SomeTitle_t02'
+            'T:\S1D1\SomeTitle_t02',
+            'T:\S1D1\Some Title 1_t03',
+            'T:\S1D1\Some Title 2_t04',
+            'T:\S1D1\Some Title3_t05',
+            'T:\S1D1\Some Title (2005)_t06'
         )
 
         # Act
         $actual = Sort-ByTitle -Files $files
 
         # Assert
-        $actual.Keys | Should -Be @(1, 2)
-        $actual.Values | Should -Be @('T:\S1D1\Some Title_t01', 'T:\S1D1\SomeTitle_t02')
+        $actual.Keys | Should -Be @(
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+        )
+        $actual.Values | Should -Be @(
+            'T:\S1D1\Some Title_t01',
+            'T:\S1D1\SomeTitle_t02',
+            'T:\S1D1\Some Title 1_t03',
+            'T:\S1D1\Some Title 2_t04',
+            'T:\S1D1\Some Title3_t05',
+            'T:\S1D1\Some Title (2005)_t06'
+        )
     }
 }
 

--- a/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
+++ b/MakeMkv/Invoke-SeasonEpisodeNaming.ps1
@@ -56,7 +56,7 @@ function Sort-ByTitle {
         [System.Collections.Generic.SortedDictionary[int, string]]$titleSort = [System.Collections.Generic.SortedDictionary[int, string]]::new()
         foreach ($file in $Files) {
             $fileNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($file)
-            $titleString = [System.Text.RegularExpressions.Regex]::Match($fileNameWithoutExtension, '(^[A-Z][0-9]|[A-Za-z\)])_t(?<TitleNumber>[0-9]+)').Groups['TitleNumber'].Value
+            $titleString = [System.Text.RegularExpressions.Regex]::Match($fileNameWithoutExtension, '(^[A-Z][0-9]|[A-Za-z\)0-9])_t(?<TitleNumber>[0-9]+)').Groups['TitleNumber'].Value
             $title = [int]::Parse($titleString)
             if ($titleSort.ContainsKey($title)) {
                 Write-Error "Duplicate Titles Found ([$title]); This Tool Cannot Be Used"


### PR DESCRIPTION
Add support for numerics at the end of a file name along with adding unit tests to validate this, as well as the case that was previously added to end with a `)`