### PR TITLE
Create Invoke-AutoDoubleEpisodeRenamer.ps1

### DIFF
--- a/MakeMkv/RenameDoubleEpisodes/Invoke-AutoDoubleEpisodeRenamer.ps1
+++ b/MakeMkv/RenameDoubleEpisodes/Invoke-AutoDoubleEpisodeRenamer.ps1
@@ -4,7 +4,10 @@
 #
 # I was not smart enough to figure out how to get FileBot to work as expected
 # but renaming the files like the above helped FileBot figure it out.
-
+#
+# 2025/03 AKO - This is no longer needed as FileBot has the ability within the
+# episode dialog to select multiple episodes, right click, then select
+# "double/triple/multi" episodes which resolves this issue.
 [CmdletBinding()]
 param (
     [Parameter(Mandatory = $true)]

--- a/MakeMkv/RenameDoubleEpisodes/Invoke-AutoDoubleEpisodeRenamer.ps1
+++ b/MakeMkv/RenameDoubleEpisodes/Invoke-AutoDoubleEpisodeRenamer.ps1
@@ -1,0 +1,38 @@
+# This was written to help rename double episodes in a format that FileBot would
+# support. These are coming from the DVD Rips but each title represents two
+# episodes.
+#
+# I was not smart enough to figure out how to get FileBot to work as expected
+# but renaming the files like the above helped FileBot figure it out.
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Path,
+    [string]
+    $SeriesName = 'Rugrats (1991)',
+    [int]
+    $Season = 3,
+    [Parameter(Mandatory = $true)]
+    [int]
+    $NextEpisode
+)
+
+
+$files = Get-ChildItem -LiteralPath $Path | Sort-Object -Property FullName
+
+foreach ($file in $files) {
+    # Format with a padded 0, FileBot seems to get confused otherwise.
+    $episodeString = "S$('{0:d2}' -f $Season)E$('{0:d2}' -f $NextEpisode)-$('{0:d2}' -f $($NextEpisode+1))"
+    $NextEpisode = $NextEpisode + 2
+
+    # Build up the new proposed file name
+    $currentFolderPath = [System.IO.Path]::GetDirectoryName($file.FullName)
+    $currentFileExtension = [System.IO.Path]::GetExtension($file.FullName)
+    $proposedFileName = "$SeriesName $episodeString$currentFileExtension"
+    $proposedNewFilePath = [System.IO.Path]::Combine($currentFolderPath, $proposedFileName)
+
+    # Now Perform the Rename/Move
+    Move-Item -LiteralPath $file.FullName -Destination $proposedNewFilePath
+}

--- a/MakeMkv/RenameDoubleEpisodes/Invoke-DoubleEpisodeRenamer.ps1
+++ b/MakeMkv/RenameDoubleEpisodes/Invoke-DoubleEpisodeRenamer.ps1
@@ -5,7 +5,10 @@
 #
 # I was not smart enough to figure out how to get FileBot to work as expected
 # but renaming the files like the above helped FileBot figure it out.
-
+#
+# 2025/03 AKO - This is no longer needed as FileBot has the ability within the
+# episode dialog to select multiple episodes, right click, then select
+# "double/triple/multi" episodes which resolves this issue.
 $files = Get-ChildItem -Path 'E:\Arthur\Season.8' | Sort-Object -Property FullName
 
 [int]$nextEpisode = 1


### PR DESCRIPTION
Create script to help automatically name titles in a double episode format.

This is no longer needed as FileBot has the ability within the episode dialog to select multiple episodes, right click, then select "double/triple/multi" episodes which resolves this issue.

However these scripts are still committed for historical reference.