### PR TITLE
Create Script to Query Jellyfin for Movies

### DIFF
--- a/Jellyfin/Get-Movies.ps1
+++ b/Jellyfin/Get-Movies.ps1
@@ -1,0 +1,34 @@
+# --- CONFIGURATION ---
+$Server = ""      # Change to your Jellyfin server URL
+$ApiKey = ""          # Replace with your API key
+$OutputCsv = "Jellyfin_MovieList.csv"
+
+# --- BUILD API URL ---
+# 'IsMovie=true' filters only movies
+$Url = "$Server/Items?IncludeItemTypes=Movie&Recursive=true&Fields=OfficialRating,Overview,ProductionYear"
+
+# --- MAKE REQUEST ---
+$Headers = @{
+    "X-Emby-Token" = $ApiKey
+}
+
+Write-Host "Querying Jellyfin server..."
+$response = Invoke-RestMethod -Uri $Url -Headers $Headers -Method Get
+
+# --- EXTRACT MOVIE DATA ---
+$movies = $response.Items | ForEach-Object {
+    [PSCustomObject]@{
+        "Title"       = if ($_.ProductionYear) { "$($_.Name) ($($_.ProductionYear))" } else { $_.Name }
+        "MPAA Rating" = $_.OfficialRating
+        "Synopsis"    = $_.Overview
+    }
+}
+
+$movies = $movies | Sort-Object -Property 'Title'
+
+# --- EXPORT TO CSV ---
+Write-Host "Writing to $OutputCsv..."
+$Utf8Bom = New-Object System.Text.UTF8Encoding($true)  # 'true' adds BOM
+[System.IO.File]::WriteAllText($OutputCsv, ($movies | ConvertTo-Csv -NoTypeInformation | Out-String), $Utf8Bom)
+
+Write-Host "Done! $($movies.Count) movies exported to $OutputCsv."


### PR DESCRIPTION
This code was created using ChatGPT.

Instructed ChatGPT to create a PowerShell script that leveraged the Jellyfin REST API to grab a list of movies with their titles in the format of `Title (Year)` (if the year is present), along with the MPAA Rating, and the Synopsis.

Out of the box this somewhat worked, however Jellyfin utilizes UTF-8 encoding which was not coming through. Reprompting ChatGPT made the suggestion to change how Export worked, it does not seem the cleanest but does work.