### PR TITLE
Get-SilenceProbabilities.ps1

### DIFF
--- a/WhisperAI/Get-SilenceProbabilities.md
+++ b/WhisperAI/Get-SilenceProbabilities.md
@@ -1,0 +1,130 @@
+# Get-SilenceProbabilities.ps1
+
+I have a large number of WAV files, many of which can sometimes consist
+completely of "silence". Historically I was using tools like Audacity to pull
+WAV Forms or passing the files into Whisper AI to understand if these were files
+I wanted to ignore. In a discussion with Copilot it made the recommendation to
+use RMS for this task which is orders of magnitude faster.
+
+## Reading the Entire File/Span<T>
+
+Out of curiosity I had Copilot write a version of this that loaded the entire
+file into memory and then used `Span<T>` to perform the same calculation
+thinking that this might speed up the process. However in testing with my
+workloads this really did not seem to speed it up. The limiting factor still
+seems to be disk I/O. I have saved this version off just in case this ever
+becomes more interesting.
+
+```csharp
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Buffers.Binary;
+using System.Numerics;
+
+public static class WavSilenceAnalyzer
+{
+    public static double Analyze(string path, double silenceThreshold, int frameMs)
+    {
+        using var fs = File.OpenRead(path);
+        using var br = new BinaryReader(fs);
+
+        // --- Parse RIFF/WAVE header ---
+        if (new string(br.ReadChars(4)) != "RIFF")
+            throw new Exception("Not RIFF");
+
+        br.ReadInt32(); // file size
+
+        if (new string(br.ReadChars(4)) != "WAVE")
+            throw new Exception("Not WAVE");
+
+        // Find fmt chunk
+        string chunkId;
+        while ((chunkId = new string(br.ReadChars(4))) != "fmt ")
+        {
+            int skip = br.ReadInt32();
+            br.ReadBytes(skip);
+        }
+
+        int fmtSize = br.ReadInt32();
+        short audioFormat = br.ReadInt16();
+        short channels = br.ReadInt16();
+        int sampleRate = br.ReadInt32();
+        br.ReadInt32(); // byteRate
+        br.ReadInt16(); // blockAlign
+        short bitsPerSample = br.ReadInt16();
+
+        if (audioFormat != 1 || bitsPerSample != 16)
+            throw new Exception("Only 16-bit PCM supported");
+
+        if (fmtSize > 16)
+            br.ReadBytes(fmtSize - 16);
+
+        // Find data chunk
+        while ((chunkId = new string(br.ReadChars(4))) != "data")
+        {
+            int skip = br.ReadInt32();
+            br.ReadBytes(skip);
+        }
+
+        int dataSize = br.ReadInt32();
+
+        // --- Single large read ---
+        byte[] pcm = br.ReadBytes(dataSize);
+
+        // Interpret as 16-bit samples
+        Span<short> samples = MemoryMarshal.Cast<byte, short>(pcm);
+
+        int samplesPerFrame = (int)(sampleRate * (frameMs / 1000.0)) * channels;
+        int totalFrames = samples.Length / samplesPerFrame;
+
+        if (totalFrames == 0)
+            return 0;
+
+        int silentFrames = 0;
+
+        // Precompute threshold² to avoid sqrt
+        double thresholdSquared = silenceThreshold * silenceThreshold;
+
+        // --- Frame loop ---
+        for (int f = 0; f < totalFrames; f++)
+        {
+            var frame = samples.Slice(f * samplesPerFrame, samplesPerFrame);
+
+            double sumSquares = 0;
+
+            if (channels == 1)
+            {
+                // Mono
+                for (int i = 0; i < frame.Length; i++)
+                {
+                    int si = frame[i];
+                    if (si < 0) si = -si;
+
+                    double d = si / 32768.0;
+                    sumSquares += d * d;
+                }
+            }
+            else
+            {
+                // Stereo → average pairs
+                for (int i = 0; i < frame.Length; i += 2)
+                {
+                    int avg = (frame[i] + frame[i + 1]) / 2;
+                    int si = avg < 0 ? -avg : avg;
+
+                    double d = si / 32768.0;
+                    sumSquares += d * d;
+                }
+            }
+
+            double rmsSquared = sumSquares / (samplesPerFrame / channels);
+
+            if (rmsSquared < thresholdSquared)
+                silentFrames++;
+        }
+
+        return (silentFrames / (double)totalFrames) * 100.0;
+    }
+}
+```

--- a/WhisperAI/Get-SlienceProbabilities.ps1
+++ b/WhisperAI/Get-SlienceProbabilities.ps1
@@ -1,0 +1,207 @@
+# Script to detect mostly‑silent WAV files using fast C#‑based RMS analysis.
+#
+# Written with the assistance of Copilot.
+
+Add-Type -Language CSharp -TypeDefinition @"
+/*
+   High‑performance WAV silence analyzer.
+
+   This routine parses a 16‑bit PCM WAV file, locates the "fmt " and "data"
+   chunks, and processes audio in fixed‑duration frames (e.g., 20 ms). Each
+   frame is read as a raw byte block and decoded sample‑by‑sample with no
+   allocations or PowerShell overhead.
+
+   For every frame, the algorithm computes RMS amplitude by accumulating the
+   sum of squared sample magnitudes (promoted to int to avoid overflow on
+   short.MinValue), then normalizing by 32768. Frames whose RMS falls below
+   the caller‑supplied silence threshold are counted as "silent".
+
+   The function returns the percentage of silent frames across the entire
+   file. This design keeps all DSP‑heavy work in C# for speed, while allowing
+   PowerShell to handle orchestration and reporting.
+*/
+using System;
+using System.IO;
+
+public static class WavSilenceAnalyzer
+{
+    /// <summary>
+    /// Analyzes a 16‑bit PCM WAV file and computes the percentage of frames
+    /// whose RMS amplitude falls below a specified silence threshold.
+    /// </summary>
+    /// <param name="path">
+    /// Full file system path to the WAV file. The file must contain a valid
+    /// RIFF/WAVE header with a PCM "fmt " chunk and a 16‑bit "data" chunk.
+    /// </param>
+    /// <param name="silenceThreshold">
+    /// Normalized RMS threshold (0–1). Frames whose RMS amplitude is below
+    /// this value are classified as silent.
+    /// </param>
+    /// <param name="frameMs">
+    /// Duration of each analysis frame in milliseconds. The method reads and
+    /// processes audio in fixed‑size blocks derived from this value.
+    /// </param>
+    /// <returns>
+    /// The percentage of analyzed frames that are considered silent.
+    /// </returns>
+    /// <remarks>
+    /// The method parses the WAV header, locates the "fmt " and "data" chunks,
+    /// and then reads the audio stream in fixed‑duration frames. Each frame is
+    /// decoded sample‑by‑sample directly from a byte buffer to avoid allocations.
+    ///
+    /// Stereo audio is downmixed by averaging left and right channels. Sample
+    /// magnitudes are promoted to <see cref="int"/> before applying absolute value
+    /// to avoid overflow on <see cref="short.MinValue"/>. RMS amplitude is computed
+    /// by accumulating squared magnitudes and normalizing by 32768.
+    ///
+    /// Frames with RMS below <paramref name="silenceThreshold"/> are counted as
+    /// silent, and the final result is expressed as a percentage of total frames.
+    /// </remarks>
+    public static double Analyze(string path, double silenceThreshold, int frameMs)
+    {
+        using (var fs = File.OpenRead(path))
+        using (var br = new BinaryReader(fs))
+        {
+            // --- Parse RIFF/WAVE header ---
+            var riff = new string(br.ReadChars(4));
+            if (riff != "RIFF") throw new Exception("Not RIFF");
+
+            br.ReadInt32(); // file size
+
+            var wave = new string(br.ReadChars(4));
+            if (wave != "WAVE") throw new Exception("Not WAVE");
+
+            // Find fmt chunk
+            string chunkId;
+            while ((chunkId = new string(br.ReadChars(4))) != "fmt ")
+            {
+                int skip = br.ReadInt32();
+                br.ReadBytes(skip);
+            }
+
+            int fmtSize = br.ReadInt32();
+            short audioFormat = br.ReadInt16();
+            short channels = br.ReadInt16();
+            int sampleRate = br.ReadInt32();
+            br.ReadInt32(); // byteRate
+            br.ReadInt16(); // blockAlign
+            short bitsPerSample = br.ReadInt16();
+
+            if (audioFormat != 1 || bitsPerSample != 16)
+                throw new Exception("Only 16-bit PCM supported");
+
+            if (fmtSize > 16)
+                br.ReadBytes(fmtSize - 16);
+
+            // Find data chunk
+            while ((chunkId = new string(br.ReadChars(4))) != "data")
+            {
+                int skip = br.ReadInt32();
+                br.ReadBytes(skip);
+            }
+
+            int dataSize = br.ReadInt32();
+            int bytesPerSample = bitsPerSample / 8;
+            int frameSamples = (int)(sampleRate * (frameMs / 1000.0));
+
+            int bytesPerFrame = frameSamples * channels * bytesPerSample;
+            byte[] buffer = new byte[bytesPerFrame];
+
+            int silentFrames = 0;
+            int totalFrames = 0;
+
+            // --- Frame loop ---
+            int read;
+            while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                int sampleCount = read / (bytesPerSample * channels);
+                if (sampleCount == 0)
+                    continue;
+
+                double sumSquares = 0;
+
+                int offset = 0;
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    short left = BitConverter.ToInt16(buffer, offset);
+                    offset += 2;
+
+                    short sample = left;
+
+                    if (channels == 2)
+                    {
+                        short right = BitConverter.ToInt16(buffer, offset);
+                        offset += 2;
+                        sample = (short)((left + right) / 2);
+                    }
+
+                    // Promote to int before abs to avoid overflow on short.MinValue
+                    int si = sample;
+                    if (si < 0) si = -si;
+
+                    double s = (double)si;
+                    sumSquares += s * s;
+                }
+
+                double rms = Math.Sqrt(sumSquares / sampleCount) / 32768.0;
+
+                if (rms < silenceThreshold)
+                    silentFrames++;
+
+                totalFrames++;
+            }
+
+            if (totalFrames == 0) return 0;
+            return (silentFrames / (double)totalFrames) * 100.0;
+        }
+    }
+}
+"@
+
+function Get-WavSilenceStats {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+        # RMS threshold for silence (normalized 0–1)
+        [double]$SilenceThreshold = 0.01,
+        # Percentage threshold for classifying a file as "silent"
+        [double]$PercentThreshold = 90
+    )
+
+    $percentSilent = [WavSilenceAnalyzer]::Analyze($FilePath, $SilenceThreshold, 20)
+
+    return [PSCustomObject]@{
+        File              = $FilePath
+        PercentSilent     = [math]::Round($percentSilent, 2)
+        IsSilentThreshold = $percentSilent -ge $PercentThreshold
+    }
+}
+
+function Get-WavSilenceReport {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        # RMS threshold for silence (normalized 0–1)
+        [double]$SilenceThreshold = 0.01,
+        # Percentage threshold for classifying a file as "silent"
+        [double]$PercentThreshold = 90
+    )
+
+    $wavFiles = Get-ChildItem -Path $Path -Filter *.wav -Recurse -File
+
+    foreach ($file in $wavFiles) {
+        try {
+            Get-WavSilenceStats -FilePath $file.FullName `
+                -SilenceThreshold $SilenceThreshold `
+                -PercentThreshold $PercentThreshold
+        }
+        catch {
+            [PSCustomObject]@{
+                File              = $file.FullName
+                PercentSilent     = 0
+                IsSilentThreshold = $false
+                Error             = $_.Exception.Message
+            }
+        }
+    }
+}

--- a/WhisperAI/Get-SlienceProbabilities.ps1
+++ b/WhisperAI/Get-SlienceProbabilities.ps1
@@ -332,3 +332,5 @@ function Get-AudioSilenceReportParallel {
 
     } -ThrottleLimit $ThrottleLimit
 }
+
+Get-AudioSilenceReportParallel


### PR DESCRIPTION
I have a large number of WAV files, many of which can sometimes consist
completely of "silence". Historically I was using tools like Audacity to pull
WAV Forms or passing the files into Whisper AI to understand if these were files
I wanted to ignore. In a discussion with Copilot it made the recommendation to
use RMS for this task which is orders of magnitude faster.