### PR TITLE
Use LiteralPath in Several Locations

### DIFF
--- a/MakeMkv/Create-Mkv.ps1
+++ b/MakeMkv/Create-Mkv.ps1
@@ -9,7 +9,7 @@ param(
 )
 
 # Normalize directory path
-$InputDirectory = (Resolve-Path $InputDirectory).Path
+$InputDirectory = (Resolve-Path -LiteralPath $InputDirectory).Path
 
 Write-Host "Scanning directory: $InputDirectory"
 
@@ -22,7 +22,7 @@ foreach ($mp4 in $mp4Files) {
     $baseName = [System.IO.Path]::GetFileNameWithoutExtension($mp4.Name)
     $srtPath = Join-Path $dir "$baseName.srt"
 
-    if (-Not (Test-Path $srtPath)) {
+    if (-Not (Test-Path -LiteralPath $srtPath)) {
         Write-Warning "No SRT found for: $($mp4.FullName)"
         continue
     }
@@ -48,7 +48,7 @@ foreach ($mp4 in $mp4Files) {
 
         # Create _Completed folder if needed
         $completedDir = Join-Path $dir "_Completed"
-        if (-not (Test-Path $completedDir)) {
+        if (-not (Test-Path -LiteralPath $completedDir)) {
             New-Item -ItemType Directory -Path $completedDir | Out-Null
         }
 

--- a/mkvtoolnix/Append-SRT.ps1
+++ b/mkvtoolnix/Append-SRT.ps1
@@ -9,11 +9,11 @@ param(
 )
 
 # Normalize directory path
-$Directory = (Resolve-Path $Directory).Path
+$Directory = (Resolve-Path -LiteralPath $Directory).Path
 $completedDir = Join-Path $Directory "_Completed"
 
 # Ensure _Completed exists
-if (-not (Test-Path $completedDir)) {
+if (-not (Test-Path -LiteralPath $completedDir)) {
     New-Item -ItemType Directory -Path $completedDir | Out-Null
 }
 
@@ -25,7 +25,7 @@ foreach ($mkv in $mkvFiles) {
     $baseName = [System.IO.Path]::GetFileNameWithoutExtension($mkv.Name)
     $srtPath = Join-Path $Directory "$baseName.en.srt"
 
-    if (-not (Test-Path $srtPath)) {
+    if (-not (Test-Path -LiteralPath $srtPath)) {
         Write-Warning "No matching .en.srt found for: $($mkv.Name)"
         continue
     }

--- a/mkvtoolnix/Append-SRTFuzzy.ps1
+++ b/mkvtoolnix/Append-SRTFuzzy.ps1
@@ -20,7 +20,7 @@ $completedDir = Join-Path $Directory "_Completed"
 $subsRoot = Join-Path $Directory "subs"
 
 # Ensure _Completed exists
-if (-not (Test-Path $completedDir)) {
+if (-not (Test-Path -LiteralPath $completedDir)) {
     New-Item -ItemType Directory -Path $completedDir | Out-Null
 }
 


### PR DESCRIPTION
PowerShell requires us to use `LiteralPath` in scenarios where we have special characters. Fix up some existing scripts to support this.