### PR TITLE
Fix LiteralPath Usage

### DIFF
--- a/mkvtoolnix/Invoke-EnglishOnlyMkv.ps1
+++ b/mkvtoolnix/Invoke-EnglishOnlyMkv.ps1
@@ -87,7 +87,7 @@ foreach ($file in $files) {
     Write-Host "Running mkvmerge..."
     & $MkvMergePath $arguments
 
-    if (-not (Test-Path $outputFile)) {
+    if (-not (Test-Path -LiteralPath $outputFile)) {
         Write-Warning "mkvmerge failed; output file not created. Skipping move."
         continue
     }


### PR DESCRIPTION
Ensure that we use `LiteralPath` when testing for file paths.